### PR TITLE
Clarify Overview so the Central summary distinguishes ai.weaviate

### DIFF
--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Weaviate is an open-source vector database that allows you to store data objects and vector embeddings from your favorite ML-models. The Weaviate connector enables seamless interaction with Weaviate instances, supporting complex vector searches and data management.
+The `ai.weaviate` module implements the [`ballerina/ai`](https://central.ballerina.io/ballerina/ai/latest) `VectorStore` interface, backed by the [Weaviate](https://weaviate.io/) open-source vector database. Use it to store and similarity-search embeddings for retrieval-augmented generation (RAG) in Ballerina AI agents.
 
 ### Key Features
 


### PR DESCRIPTION
### Purpose

The first paragraph of the package Overview is what Ballerina Central stores as the package **summary**, and that summary is the `description` the Ballerina Copilot **library-search tool** returns to the agent when it selects a library. Across the OpenAI / Azure OpenAI / `ai.*` packages this first paragraph was a generic vendor blurb, so their summaries were nearly identical and an agent could not reliably tell them apart (e.g. an agent-framework model provider vs a direct REST connector).

### Change

Rewrite the Overview's first paragraph into a single, **capability-first** sentence that states what this module uniquely is — grounded in its actual API and `Ballerina.toml` type keywords — so the summary alone disambiguates it from its siblings. The now-redundant generic second paragraph is merged away. **Key Features** and everything below are untouched; `Module.md` is synced where present.

> Draft: opening for wording review. Part of a coordinated pass to disambiguate the AI/LLM package summaries surfaced by Copilot library search.

🤖 Generated with [Claude Code](https://claude.com/claude-code)